### PR TITLE
Edited drop.out expected results

### DIFF
--- a/expected/drop.out
+++ b/expected/drop.out
@@ -43,14 +43,12 @@ select Quote_count('ABB');
 select * from Quote_get('IBM');
  symbol | day | open | high | low | close | volume 
 --------+-----+------+------+-----+-------+--------
-        |     |      |      |     |       | 
-(1 row)
+(0 rows)
 
 select * from Quote_get('ABB');
  symbol | day | open | high | low | close | volume 
 --------+-----+------+------+-----+-------+--------
-        |     |      |      |     |       | 
-(1 row)
+(0 rows)
 
 select CrashLog_delete('2014-04-14 11:54', '2014-04-14 11:56');
  crashlog_delete 


### PR DESCRIPTION
I ran the tests for imcs for Postgres 15.0, 15.1, 15.2, and 15.3 and noticed that the `drop.sql` test repetitively fails. I think this is the test's fault, because on the table quote, where there are no records, the get() operation returns one empty row, and Postgres is outputting zero rows, which I think is fair. Therefore, I changed the test to reflect this.